### PR TITLE
chore: add support for an active PA environment (MOBILE-17358)

### DIFF
--- a/app/src/main/java/com/contentsquare/android/sample/SampleApplication.kt
+++ b/app/src/main/java/com/contentsquare/android/sample/SampleApplication.kt
@@ -5,14 +5,22 @@ import android.app.Application
 import android.os.Bundle
 import com.contentsquare.CSQ
 import com.contentsquare.android.sample.crash.CrashHelper
+import com.contentsquare.api.model.ProductAnalyticsOptions
 
 class SampleApplication : Application() {
 
     override fun onCreate() {
         super.onCreate()
 
-        // If you want to also activate Product Analytics, you have to uncomment this line and update the ENV_ID.
-        // CSQ.configureProductAnalytics(this, "ENV_ID", /* options */)
+        CSQ.configureProductAnalytics(
+            context = this,
+            envId = "3521501044",
+            options = ProductAnalyticsOptions(
+                enableViewAutocapture = true,
+                // Pageview capture is turned off in favor of manual screen tracking in this sample.
+                disablePageviewAutocapture = true
+            )
+        )
         CSQ.start(this)
         CSQ.optIn(this)
         CrashHelper.init(this)


### PR DESCRIPTION
We had a customer that requested a sample where PA was enabled. I setup a new PA environment for use in this sample and enabled autocapture, but disabled pageview autocapture as to not interfere with the manual screenview tracking that was already setup in the app.

refs MOBILE-17358