### PR TITLE
Add network security config to trust user certificates

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -13,7 +13,8 @@
         android:supportsRtl="true"
         android:theme="@style/Theme.AndroidSampleApp"
         android:name=".SampleApplication"
-        tools:ignore="GoogleAppIndexingWarning">
+        tools:ignore="GoogleAppIndexingWarning"
+        android:networkSecurityConfig="@xml/network_security_config">
 
         <activity
             android:name=".MainActivity"

--- a/app/src/main/java/com/contentsquare/android/sample/analytics/Analytics.kt
+++ b/app/src/main/java/com/contentsquare/android/sample/analytics/Analytics.kt
@@ -55,5 +55,6 @@ object Analytics {
 
     fun sendUserIdentifier(identifier: String) {
         CSQ.sendUserIdentifier(identifier)
+        CSQ.identify(identifier)
     }
 }

--- a/app/src/main/res/xml/network_security_config.xml
+++ b/app/src/main/res/xml/network_security_config.xml
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="utf-8"?>
+<network-security-config>
+    <base-config cleartextTrafficPermitted="true">
+        <trust-anchors>
+            <certificates src="system" />
+            <certificates src="user" />
+        </trust-anchors>
+    </base-config>
+</network-security-config>


### PR DESCRIPTION
## Summary

- Add `network_security_config.xml` to trust both system and user-installed CA certificates, and allow cleartext traffic — enables MITM proxying (e.g. Charles, mitmproxy) for local development/testing
- Wire the config into `AndroidManifest.xml` via `android:networkSecurityConfig`
- Add `CSQ.identify(identifier)` call alongside the existing `sendUserIdentifier` in `Analytics.kt`

## Test plan

- [ ] Build and run the app on a device/emulator
- [ ] Confirm HTTPS traffic can be intercepted via a proxy with a user-installed certificate
- [ ] Confirm `CSQ.identify` is called when a user identifier is sent

🤖 Generated with [Claude Code](https://claude.com/claude-code)