### PR TITLE
chore(android-sample): bump Contentsquare SDK to 1.11.2

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -49,8 +49,8 @@ kotlin {
 }
 
 dependencies {
-    implementation("com.contentsquare.android:sdk:1.11.1")
-    implementation("com.contentsquare.android:sdk-compose:1.11.1")
+    implementation("com.contentsquare.android:sdk:1.11.2")
+    implementation("com.contentsquare.android:sdk-compose:1.11.2")
 
     implementation("androidx.core:core-ktx:1.17.0")
     implementation("androidx.appcompat:appcompat:1.7.1")


### PR DESCRIPTION
Summary
Update the Android sample app to use Contentsquare SDK 1.11.2.

Detailed Changes
- Updated `com.contentsquare.android:sdk` from `1.11.1` to `1.11.2`.
- Updated `com.contentsquare.android:sdk-compose` from `1.11.1` to `1.11.2`.
- No source code, configuration, or integration changes were needed beyond the dependency bump.

Verification
- Ran the debug assemble build for the sample app.
- The build completed successfully.
- A non-blocking Gradle warning appeared about `buildConfig` being disabled, but it did not affect the result.

Risks / Notes
- This is a dependency-only update, so any behavior changes would come from the upstream SDK release.
- No app logic changed as part of this upgrade.

Co-authored-by: loop-o-matic
Generated-with: github-copilot/gpt-5.4-mini